### PR TITLE
Fix the sign of Lunar Lander env

### DIFF
--- a/MujocoBenchmarks/src/mujocobenchmarks/main.py
+++ b/MujocoBenchmarks/src/mujocobenchmarks/main.py
@@ -6,7 +6,6 @@ import gym
 import numpy as np
 from bencherscaffold.protoclasses.bencher_pb2 import BenchmarkRequest, EvaluationResult
 from bencherscaffold.dual_stack_service import DualStackGRCPService, add_listen_argument, resolve_listen_entries
-from gym.envs.box2d import LunarLander
 
 from mujocobenchmarks.functions import func_factories
 
@@ -90,19 +89,20 @@ class MujocoServiceServicer(DualStackGRCPService):
             )
         elif request.benchmark.name == 'lunarlander':
             env = gym.make("LunarLander-v2")
-            total_reward = 0
-            steps = 0
-            s = env.reset()
-            while True:
-                a = heuristic_controller(s, x.squeeze())
-                s, r, terminated, _ = env.step(a)
-                total_reward += r
+            try:
+                total_reward = 0
+                s = env.reset()
+                while True:
+                    a = heuristic_controller(s, x.squeeze())
+                    s, r, terminated, _ = env.step(a)
+                    total_reward += r
 
-                steps += 1
-                if terminated:
-                    break
+                    if terminated:
+                        break
+            finally:
+                env.close()
             result = EvaluationResult(
-                value=total_reward
+                value=-total_reward
             )
         else:
             raise ValueError("Invalid benchmark name")


### PR DESCRIPTION
Hi Leonard,

First of all, thank you for creating `bencher`! It's amazing, and I hope this package becomes the default for BO research.

I believe I found a small bug for the Lunar Lander env? Here's a small description (made by Claude):
*`MujocoBenchmarks/src/mujocobenchmarks/main.py:105` returns `value=total_reward` for `lunarlander`. Every other benchmark in this repo returns a value to **minimize**. Downstream consumers that negate (as the convention requires) therefore end up **maximizing the negative reward — searching for the worst possible lander.***

Also, on the way I removed an unused `step` variable and an unused `LunarLander` import. Hope this is useful, lemme know if you want me to change something. :)